### PR TITLE
update path replacement for pixi wrappers

### DIFF
--- a/src/host_init_interactive.sh
+++ b/src/host_init_interactive.sh
@@ -124,9 +124,6 @@ fi
 
 # This section will rename the files under /opt/share/.pixi/bin to point to the write location
 # This is so non-admin users will be able to use shared packages
-for file in /mnt/efs/shared/.pixi/bin/*; do
-    if [[ $(basename "$file") == "pixi" ]]; then
-        continue
-    fi
-    sed -i 's|/home/ubuntu|/opt/shared|g' "$file"
+for file in /mnt/efs/shared/.pixi/bin/trampoline_configuration/*; do
+    sed -i 's|/home/ubuntu/.pixi|/opt/shared/.pixi|g' "$file"
 done

--- a/src/host_init_interactive.sh
+++ b/src/host_init_interactive.sh
@@ -122,8 +122,8 @@ if [ -d "/mnt/efs/$FLOAT_USER/.profile" ]; then
     sudo chgrp users /mnt/efs/$FLOAT_USER/.profile
 fi
 
-# This section will rename the files under /opt/share/.pixi/bin to point to the write location
+# This section will rename the files under /opt/share/.pixi/bin/trampoline_configuration to point to the right location
 # This is so non-admin users will be able to use shared packages
-for file in /mnt/efs/shared/.pixi/bin/trampoline_configuration/*; do
+for file in /mnt/efs/shared/.pixi/bin/trampoline_configuration/*.json; do
     sed -i 's|/home/ubuntu/.pixi|/opt/shared/.pixi|g' "$file"
 done


### PR DESCRIPTION
A small fix is needed for the new version of `pixi` - the files in `.pixi/bin` are now all copies or hardlinks of `.pixi/bin/trampoline_configuration/trampoline_bin` which load a configuration `.json` file for each executable.  These `.json` files are all stored in `.pixi/bin/trampoline_configuration`, so we can just loop through the `.json` files in this folder and do the same path replacement as before.